### PR TITLE
Update gemspec for chef gem to minimum of chef v12

### DIFF
--- a/seiso-import_chef.gemspec
+++ b/seiso-import_chef.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
 
-  spec.add_runtime_dependency "chef", "~> 11.8"
+  spec.add_runtime_dependency "chef", "~> 12"
   spec.add_runtime_dependency "seiso-connector", "~> 0.1"
 end


### PR DESCRIPTION
Simple change that requires minimum runtime version of chef gem to be 12, instead of 11.8.

NOTE: The API changes between Chef 11/12, so 12 is not backwards compatible and thus nor will 11 work with 12 (you'll get HTTP/401 if you try and get nodes.all from Chef 11 gem to a Chef 12 server).